### PR TITLE
Fix stuck click ripple, light-mode contrast, and rework certificates

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,13 +62,16 @@
   --border: rgba(15,23,42,0.1);
   --border-strong: rgba(15,23,42,0.16);
   --text: #10141c;
-  --text-dim: #4b5566;
-  --text-faint: #7b8494;
-  --cyan: #0891b2;
+  --text-dim: #414b5c;
+  /* Both of these were a shade too light against #f4f6fa — --text-faint landed
+     at 3.48:1 and --cyan at 3.68:1, under the 4.5:1 needed for body text.
+     Darkened to clear it; the dark theme is unaffected. */
+  --text-faint: #5a6474;
+  --cyan: #06687f;
   --cyan-dim: #0e7490;
   --cyan-glow: rgba(8,145,178,0.35);
-  --amber: #c2740a;
-  --violet: #7c3aed;
+  --amber: #9a5c05;
+  --violet: #6d28d9;
 }
 /* A handful of surfaces use fixed dark colors directly rather than the
    variables above (nav backdrop, overlays, code/HUD panels) since those
@@ -85,6 +88,39 @@
 }
 [data-theme="light"] .section-head::before{ opacity:0.6; }
 [data-theme="light"] #particleCanvas, [data-theme="light"] .aurora{ opacity:0.4; }
+
+/* These two carry text in var(--text)/var(--text-faint) on a hardcoded near-
+   black pill. In light mode that became dark-on-dark — the orbiting hero
+   labels (CAD, Python, …) measured 1.03:1, i.e. effectively invisible. */
+[data-theme="light"] .orbit-icon{
+  background:rgba(255,255,255,0.92); border-color:rgba(15,23,42,0.14);
+  box-shadow:0 2px 10px rgba(15,23,42,0.08);
+}
+[data-theme="light"] .blueprint-tag{ background:rgba(255,255,255,0.82); }
+
+/* Timeline accents are tuned for a black canvas; at 23px on white they came
+   in between 1.8:1 and 2.2:1. These are the same hues, darkened. */
+[data-theme="light"] .tl-accent-cyan{ --accent:#0e7490; }
+[data-theme="light"] .tl-accent-violet{ --accent:#7e22ce; }
+[data-theme="light"] .tl-accent-amber{ --accent:#a16207; }
+[data-theme="light"] .tl-accent-emerald{ --accent:#15803d; }
+[data-theme="light"] .tl-accent-rose{ --accent:#be123c; }
+[data-theme="light"] .tl-accent-orange{ --accent:#c2410c; }
+[data-theme="light"] .stat-accent-cyan{ --accent:#0e7490; }
+[data-theme="light"] .stat-accent-violet{ --accent:#6d28d9; }
+[data-theme="light"] .stat-accent-amber{ --accent:#a16207; }
+[data-theme="light"] .stat-accent-emerald{ --accent:#15803d; }
+[data-theme="light"] .fact-row-cyan{ --accent:#0e7490; }
+[data-theme="light"] .fact-row-violet{ --accent:#6d28d9; }
+[data-theme="light"] .fact-row-amber{ --accent:#a16207; }
+[data-theme="light"] .fact-row-emerald{ --accent:#15803d; }
+[data-theme="light"] .fact-row-rose{ --accent:#be123c; }
+
+[data-theme="light"] .repo-view-details{ color:#b8430b; }
+[data-theme="light"] .repo-view-details:hover{ border-color:rgba(184,67,11,0.4); background:rgba(184,67,11,0.1); }
+/* The category tint is written as an inline style from JS, so it can't be
+   restated here by name — darken whatever colour lands on the element. */
+[data-theme="light"] .repo-cat-badge{ filter:brightness(0.62) saturate(1.35); }
 
 *{ box-sizing: border-box; margin:0; padding:0; }
 html{ scroll-behavior:smooth; background:var(--bg); scrollbar-gutter:stable; }
@@ -143,8 +179,12 @@ html{ scrollbar-color: var(--cyan-dim) var(--bg-elevated); scrollbar-width: thin
 .cursor-ring.clicking{ width:22px; height:22px; margin:-11px 0 0 -11px; }
 .cursor-dot.text-mode, .cursor-ring.text-mode{ opacity:0; }
 
+/* Positioned with left/top rather than a transform: the keyframes below
+   animate `transform`, and an animation beats an inline style in the cascade,
+   so a translate set on the element would be wiped the moment the animation
+   started and every ripple would play from the top-left corner. */
 .cursor-ripple{
-  position:fixed; top:0; left:0; z-index:9998; pointer-events:none; border-radius:50%;
+  position:fixed; z-index:9998; pointer-events:none; border-radius:50%;
   width:10px; height:10px; margin:-5px 0 0 -5px; border:1.5px solid var(--cyan);
   animation:cursor-ripple-out .55s var(--ease) forwards;
 }
@@ -165,7 +205,12 @@ html{ scrollbar-color: var(--cyan-dim) var(--bg-elevated); scrollbar-width: thin
 @media (prefers-reduced-motion: reduce){
   .loader{ transition: opacity .2s linear, visibility .2s; }
   .loader.done{ transform:none; }
-  .loader.done ~ *{ animation:none; }
+  /* Only the loader's own decoration is stilled here. A blanket
+     `.loader.done ~ *{animation:none}` would match every top-level element in
+     the body — including the click ripple, which is appended to <body> and so
+     is a sibling of the loader. With its animation cancelled the ripple's
+     `animationend` never fires, the cleanup never runs, and a circle is left
+     sitting on the page at every click. */
   .loader-scanline, .loader-orb, .loader-orbit-dot,
   .loader-dash-ring, .loader-dash-ring-2, .loader-photo-glow{ animation:none; }
 }
@@ -630,9 +675,61 @@ html{ scrollbar-color: var(--cyan-dim) var(--bg-elevated); scrollbar-width: thin
 .cert-thumb{ position:relative; aspect-ratio:16/10.6; overflow:hidden; background:#0d1016; }
 .cert-thumb img{ width:100%; height:100%; object-fit:cover; transition:transform .5s var(--ease); }
 .cert-card:hover .cert-thumb img{ transform:scale(1.06); }
-.cert-info{ padding:18px 20px; }
-.cert-info h4{ font-family:var(--font-display); font-size:14.5px; margin-bottom:6px; }
-.cert-info p{ font-size:11px; color:var(--text-faint); }
+/* Single-line caption. Titles vary a lot in length, so anything that doesn't
+   fit is clipped rather than allowed to wrap and make the cards uneven — the
+   full text stays available via the title attribute and the modal. */
+.cert-info{ padding:16px 18px; }
+.cert-info h4{
+  font-family:var(--font-display); font-size:14px; font-weight:600; line-height:1.35;
+  white-space:nowrap; overflow:hidden; text-overflow:ellipsis;
+}
+
+/* ---- tiers ----
+   Rank is carried by the metal: gold for research and internships, silver for
+   substantial courses, bronze for one-off masterclasses and short sessions. */
+.cert-tier-gold  { --tier-a:#f7dc8a; --tier-b:#b8860b; --tier-ink:#4a3505; --tier-glow:rgba(212,160,23,0.34); }
+.cert-tier-silver{ --tier-a:#e8edf3; --tier-b:#8c99a8; --tier-ink:#2b3440; --tier-glow:rgba(160,175,190,0.30); }
+.cert-tier-bronze{ --tier-a:#e8b48a; --tier-b:#98572b; --tier-ink:#40200d; --tier-glow:rgba(176,101,54,0.28); }
+
+/* Gradient ring drawn as a masked overlay, so the metal reads as a real edge
+   rather than a flat border colour. */
+.cert-card[class*="cert-tier-"]::after{
+  content:''; position:absolute; inset:0; border-radius:inherit; z-index:3; pointer-events:none;
+  padding:2px; background:linear-gradient(140deg, var(--tier-a), var(--tier-b) 42%, var(--tier-a) 78%, var(--tier-b));
+  -webkit-mask:linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  -webkit-mask-composite:xor; mask:linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  mask-composite:exclude;
+}
+.cert-card[class*="cert-tier-"]{ border-color:transparent; }
+.cert-card[class*="cert-tier-"]:hover{
+  border-color:transparent;
+  box-shadow:0 18px 40px rgba(0,0,0,0.35), 0 0 26px var(--tier-glow);
+}
+
+.cert-badge{
+  position:absolute; top:12px; left:12px; z-index:4;
+  display:inline-flex; align-items:center; gap:5px;
+  padding:5px 11px; border-radius:100px;
+  font-family:var(--font-mono); font-size:9.5px; font-weight:700;
+  letter-spacing:0.09em; text-transform:uppercase; white-space:nowrap;
+  color:var(--tier-ink);
+  background:linear-gradient(135deg, var(--tier-a), var(--tier-b));
+  box-shadow:0 3px 12px rgba(0,0,0,0.32), inset 0 1px 0 rgba(255,255,255,0.45);
+}
+.cert-badge svg{ width:11px; height:11px; flex-shrink:0; }
+
+/* Shown when a certificate's scan isn't in assets/certs yet, so a missing file
+   reads as a deliberate placeholder rather than a broken-image icon. It swaps
+   itself out automatically once the file is added. */
+.cert-thumb.is-missing img{ visibility:hidden; }
+.cert-thumb.is-missing::after{
+  content:'Scan not uploaded yet';
+  position:absolute; inset:0; display:flex; align-items:center; justify-content:center;
+  font-family:var(--font-mono); font-size:11px; letter-spacing:0.06em; text-align:center; padding:0 18px;
+  color:var(--text-faint);
+  background:repeating-linear-gradient(135deg, rgba(255,255,255,0.03) 0 10px, transparent 10px 20px);
+  border-bottom:1px solid var(--border);
+}
 
 /* hover-revealed action pills, bottom-right of the thumbnail */
 .cert-actions{ position:absolute; right:12px; bottom:12px; display:flex; align-items:center; gap:8px; z-index:2;
@@ -995,6 +1092,81 @@ html{ scrollbar-color: var(--cyan-dim) var(--bg-elevated); scrollbar-width: thin
 .form-row input:focus, .form-row textarea:focus{ border-color:var(--cyan-dim); background:rgba(79,216,255,0.03); }
 .form-note{ margin-top:14px; font-size:11px; color:var(--text-faint); text-align:center; }
 .submit-success{ color:var(--cyan); }
+
+/* ================= MESSAGE SENT OVERLAY ================= */
+.sent-overlay{
+  position:fixed; inset:0; z-index:9700; display:flex; align-items:center; justify-content:center;
+  padding:24px; background:rgba(4,5,7,0.72); backdrop-filter:blur(10px); -webkit-backdrop-filter:blur(10px);
+  opacity:0; visibility:hidden; transition:opacity .35s var(--ease), visibility .35s;
+}
+[data-theme="light"] .sent-overlay{ background:rgba(15,23,42,0.5); }
+.sent-overlay.open{ opacity:1; visibility:visible; }
+
+.sent-card{
+  position:relative; width:min(420px,100%); padding:44px 32px 30px; text-align:center;
+  border-radius:26px; border:1px solid var(--border-strong); background:var(--card);
+  box-shadow:0 40px 90px rgba(0,0,0,0.55), 0 0 0 1px rgba(79,216,255,0.08);
+  transform:translateY(22px) scale(.94); opacity:0;
+  transition:transform .5s var(--ease), opacity .4s var(--ease);
+}
+.sent-overlay.open .sent-card{ transform:none; opacity:1; }
+
+/* --- the mark: two expanding rings behind a check that draws itself --- */
+.sent-mark{ position:relative; width:96px; height:96px; margin:0 auto 22px; display:flex; align-items:center; justify-content:center; }
+.sent-ring{
+  position:absolute; inset:0; border-radius:50%; border:2px solid var(--cyan); opacity:0;
+}
+.sent-overlay.open .sent-ring{ animation:sent-ring-out 1.1s var(--ease) .18s forwards; }
+.sent-overlay.open .sent-ring-2{ animation-delay:.42s; }
+@keyframes sent-ring-out{
+  0%{ transform:scale(.6); opacity:.75; }
+  100%{ transform:scale(1.85); opacity:0; }
+}
+.sent-check{ width:96px; height:96px; position:relative; z-index:1; }
+.sent-check-circle{
+  stroke:var(--cyan); stroke-width:2.5; stroke-dasharray:151; stroke-dashoffset:151;
+  filter:drop-shadow(0 0 8px var(--cyan-glow));
+}
+.sent-check-path{
+  stroke:var(--cyan); stroke-width:4; stroke-linecap:round; stroke-linejoin:round;
+  stroke-dasharray:40; stroke-dashoffset:40;
+  filter:drop-shadow(0 0 6px var(--cyan-glow));
+}
+.sent-overlay.open .sent-check-circle{ animation:sent-draw 0.55s var(--ease) .1s forwards; }
+.sent-overlay.open .sent-check-path{ animation:sent-draw 0.4s var(--ease) .5s forwards; }
+@keyframes sent-draw{ to{ stroke-dashoffset:0; } }
+
+.sent-title{
+  font-family:var(--font-display); font-size:25px; font-weight:700; letter-spacing:-0.01em; margin-bottom:9px;
+  opacity:0; transform:translateY(10px);
+}
+.sent-sub{ font-size:13.5px; line-height:1.6; color:var(--text-dim); margin-bottom:24px; opacity:0; transform:translateY(10px); }
+.sent-close{ opacity:0; transform:translateY(10px); }
+.sent-overlay.open .sent-title{ animation:sent-rise .5s var(--ease) .62s forwards; }
+.sent-overlay.open .sent-sub{ animation:sent-rise .5s var(--ease) .72s forwards; }
+.sent-overlay.open .sent-close{ animation:sent-rise .5s var(--ease) .82s forwards; }
+@keyframes sent-rise{ to{ opacity:1; transform:none; } }
+
+/* --- confetti sparks, positioned by JS --- */
+.sent-sparks{ position:absolute; inset:0; overflow:hidden; border-radius:inherit; pointer-events:none; }
+.sent-spark{
+  position:absolute; top:76px; left:50%; width:7px; height:7px; border-radius:2px;
+  opacity:0; transform-origin:center;
+}
+.sent-overlay.open .sent-spark{ animation:sent-spark-fly .95s var(--ease) forwards; }
+@keyframes sent-spark-fly{
+  0%{ opacity:0; transform:translate(-50%,-50%) rotate(0deg) scale(.4); }
+  18%{ opacity:1; }
+  100%{ opacity:0; transform:translate(calc(-50% + var(--dx)), calc(-50% + var(--dy))) rotate(var(--rot)) scale(1); }
+}
+
+@media (prefers-reduced-motion: reduce){
+  .sent-card{ transition:opacity .2s linear; transform:none; }
+  .sent-overlay.open .sent-ring, .sent-overlay.open .sent-spark{ animation:none; }
+  .sent-overlay.open .sent-check-circle, .sent-overlay.open .sent-check-path{ animation:none; stroke-dashoffset:0; }
+  .sent-title, .sent-sub, .sent-close{ opacity:1; transform:none; }
+  .sent-overlay.open .sent-title, .sent-overlay.open .sent-sub, .sent-overlay.open .sent-close{ animation:none; }
+}
 .submit-error{ color:#f57272; }
 
 /* ================= FOOTER ================= */
@@ -1834,6 +2006,24 @@ html{ -webkit-text-size-adjust:100%; text-size-adjust:100%; }
   </div>
 </div>
 
+<!-- ============ MESSAGE SENT ============ -->
+<div class="sent-overlay" id="sentOverlay" role="alertdialog" aria-live="assertive" aria-hidden="true">
+  <div class="sent-card">
+    <div class="sent-sparks" id="sentSparks"></div>
+    <div class="sent-mark">
+      <span class="sent-ring"></span>
+      <span class="sent-ring sent-ring-2"></span>
+      <svg class="sent-check" viewBox="0 0 52 52" aria-hidden="true">
+        <circle class="sent-check-circle" cx="26" cy="26" r="24" fill="none"/>
+        <path class="sent-check-path" fill="none" d="M14.5 27.5l7.5 7.5 16-16"/>
+      </svg>
+    </div>
+    <h3 class="sent-title">Message Sent</h3>
+    <p class="sent-sub" id="sentSub">Thanks — it's landed in my inbox. I'll get back to you shortly.</p>
+    <button type="button" class="btn btn-ghost sent-close" id="sentClose"><span>Close</span></button>
+  </div>
+</div>
+
 
 <!-- ============ EXPERIENCE ============ -->
 <section class="section" id="experience">
@@ -2223,8 +2413,40 @@ document.addEventListener('DOMContentLoaded', () => {
   initSectionGlowWidth();
   renderCertificates();
   loadGitHubRepos();
+  prefetchMedia();
   document.getElementById('yearNow').textContent = new Date().getFullYear();
 });
+
+/* ---------------- MEDIA PREFETCH ----------------
+   Project shots and the remaining certificates only appear once a modal is
+   opened or the grid is expanded, so on their own they download at the moment
+   they are first needed and visibly pop in. Pull the whole set into cache in
+   the background instead: it costs a little bandwidth after first paint but
+   means every image is already decoded by the time it is shown.
+
+   Deliberately started after the page is interactive and drip-fed a few at a
+   time, so it never competes with the hero image or the GitHub request. */
+function prefetchMedia() {
+  const urls = [
+    ...CERTIFICATES.map(c => c.file),
+    ...Object.values(PROJECT_IMAGES)
+  ];
+
+  let i = 0;
+  const CONCURRENCY = 4;
+  function next() {
+    if (i >= urls.length) return;
+    const img = new Image();
+    img.decoding = 'async';
+    img.fetchPriority = 'low';
+    img.onload = img.onerror = next;
+    img.src = urls[i++];
+  }
+
+  const start = () => { for (let k = 0; k < CONCURRENCY; k++) next(); };
+  if ('requestIdleCallback' in window) requestIdleCallback(start, { timeout: 2000 });
+  else setTimeout(start, 600);
+}
 
 /* ---------------- CURSOR ---------------- */
 function initCursor() {
@@ -2257,9 +2479,16 @@ function initCursor() {
   function spawnRipple(x, y) {
     const r = document.createElement('div');
     r.className = 'cursor-ripple';
-    r.style.transform = `translate3d(${x}px, ${y}px, 0)`;
+    r.style.left = x + 'px';
+    r.style.top = y + 'px';
     document.body.appendChild(r);
-    r.addEventListener('animationend', () => r.remove());
+    // `animationend` is the normal cleanup path, but it never fires if the
+    // animation doesn't run — a reduced-motion rule, a stylesheet that failed
+    // to load, a backgrounded tab. Without a fallback the ripple is orphaned
+    // and stays on the page as a stray circle, so back it with a timer.
+    const kill = () => r.remove();
+    r.addEventListener('animationend', kill);
+    setTimeout(kill, 1000);
   }
 
   // ring simply trails the pointer with a smooth, even lerp — no
@@ -3836,20 +4065,59 @@ function closeRepoModal() {
 }
 
 /* ---------------- CERTIFICATES ---------------- */
+/* Tier drives both the ordering and the metal on the card.
+     research   — research internships, always first
+     internship — other internships / placements
+     course     — a month or more of structured work
+     session    — one-off masterclasses, webinars, short sessions
+   `on` is the completion date, used to sort within a tier (newest first). */
+const CERT_TIERS = {
+  research:   { rank: 0, metal: 'gold',   label: 'Research Intern' },
+  internship: { rank: 1, metal: 'gold',   label: 'Internship' },
+  course:     { rank: 2, metal: 'silver', label: 'Course' },
+  session:    { rank: 3, metal: 'bronze', label: 'Masterclass' }
+};
+
 const CERTIFICATES = [
-  { file: 'assets/certs/certificate-1.jpg', title: 'AI Revolution — 1 Month AI Practical Course', issuer: 'Study & Jobs Zone', date: '2026' },
-  { file: 'assets/certs/certificate-2.jpg', title: 'Agentic AI: From Idea to Deployment', issuer: 'Peer Bridge, NUST Student Community', date: '2026' },
-  { file: 'assets/certs/certificate-3.jpg', title: 'Seizing the Full Potential of AI', issuer: 'ADB Institute', date: '2026' },
-  { file: 'assets/certs/certificate-4.jpg', title: 'Building Digital Clones with AI', issuer: 'DataCrumbs', date: '2026' },
-  { file: 'assets/certs/certificate-5.jpg', title: 'Cybersecurity', issuer: 'ADB Institute', date: '2026' },
-  { file: 'assets/certs/certificate-6.jpg', title: 'Digital Technology for Energy Efficiency', issuer: 'ADB Institute', date: '2026' },
-  { file: 'assets/certs/certificate-7.jpg', title: 'Accelerating Private Sector Action to Respond to Climate Change', issuer: 'ADB Institute', date: '2026' }
-];
+  { file: 'assets/certs/aims-research-internship.jpg', tier: 'research', on: '2026-08-04',
+    title: 'Research Internship — AIMS Lab, NUST', issuer: 'SMME / SINES, NUST' },
+
+  { file: 'assets/certs/certificate-1.jpg', tier: 'course', on: '2026-01-01',
+    title: 'AI Revolution — 1 Month AI Practical Course', issuer: 'Study & Jobs Zone' },
+
+  { file: 'assets/certs/datacrumbs-professional-presence.jpg', tier: 'session', on: '2026-08-06',
+    title: 'Build Your Professional Presence', issuer: 'DataCrumbs' },
+  { file: 'assets/certs/certificate-2.jpg', tier: 'session', on: '2026-01-06',
+    title: 'Agentic AI: From Idea to Deployment', issuer: 'Peer Bridge, NUST Student Community' },
+  { file: 'assets/certs/certificate-3.jpg', tier: 'session', on: '2026-01-05',
+    title: 'Seizing the Full Potential of AI', issuer: 'ADB Institute' },
+  { file: 'assets/certs/certificate-4.jpg', tier: 'session', on: '2026-01-04',
+    title: 'Building Digital Clones with AI', issuer: 'DataCrumbs' },
+  { file: 'assets/certs/certificate-5.jpg', tier: 'session', on: '2026-01-03',
+    title: 'Cybersecurity', issuer: 'ADB Institute' },
+  { file: 'assets/certs/certificate-6.jpg', tier: 'session', on: '2026-01-02',
+    title: 'Digital Technology for Energy Efficiency', issuer: 'ADB Institute' },
+  { file: 'assets/certs/certificate-7.jpg', tier: 'session', on: '2026-01-01',
+    title: 'Accelerating Private Sector Action to Respond to Climate Change', issuer: 'ADB Institute' }
+]
+  // Gold first, then silver, then bronze; newest first inside each tier.
+  .sort((a, b) => {
+    const ra = CERT_TIERS[a.tier].rank, rb = CERT_TIERS[b.tier].rank;
+    return ra !== rb ? ra - rb : (b.on || '').localeCompare(a.on || '');
+  });
 const CERT_PAGE_SIZE = 3;
 let showAllCerts = false;
 
 const ICON_EYE = '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7Z"/><circle cx="12" cy="12" r="3"/></svg>';
 const ICON_DOWNLOAD = '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 3v12"/><path d="m7 10 5 5 5-5"/><path d="M5 21h14"/></svg>';
+const ICON_MEDAL = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round"><path d="M7.2 3h9.6l-3.4 6.2h-2.8L7.2 3Z"/><circle cx="12" cy="15.5" r="5.5"/></svg>';
+
+function formatCertDate(on) {
+  if (!on) return '';
+  const d = new Date(on + 'T00:00:00');
+  if (isNaN(d)) return on;
+  return d.toLocaleDateString('en-GB', { month: 'short', year: 'numeric' });
+}
 
 function renderCertificates() {
   const grid = document.getElementById('certGrid');
@@ -3858,21 +4126,25 @@ function renderCertificates() {
   const displayList = showAllCerts ? CERTIFICATES : CERTIFICATES.slice(0, CERT_PAGE_SIZE);
   const hiddenCount = CERTIFICATES.length - displayList.length;
 
-  const cardsHtml = displayList.map((c, i) => `
-    <div class="cert-card js-reveal in-view" data-cert-index="${i}" style="--rd:${(i % 4) * 0.06}s">
+  const cardsHtml = displayList.map((c, i) => {
+    const tier = CERT_TIERS[c.tier] || CERT_TIERS.session;
+    return `
+    <div class="cert-card cert-tier-${tier.metal} js-reveal in-view" data-cert-index="${i}" style="--rd:${(i % 4) * 0.06}s">
       <div class="cert-thumb">
-        <img src="${c.file}" alt="${escapeHtml(c.title)}" loading="lazy">
+        <span class="cert-badge">${ICON_MEDAL}${escapeHtml(tier.label)}</span>
+        <img src="${c.file}" alt="${escapeHtml(c.title)}" loading="eager" decoding="async" fetchpriority="high"
+             onerror="this.closest('.cert-thumb').classList.add('is-missing')">
         <div class="cert-actions">
           <button type="button" class="cert-btn cert-btn-download" data-action="download" title="Download">${ICON_DOWNLOAD}</button>
           <button type="button" class="cert-btn cert-btn-view" data-action="view">${ICON_EYE}<span>Full View</span></button>
         </div>
       </div>
       <div class="cert-info">
-        <h4>${escapeHtml(c.title)}</h4>
-        <p class="mono">${escapeHtml(c.issuer)} · ${escapeHtml(c.date)}</p>
+        <h4 title="${escapeHtml(c.title)}">${escapeHtml(c.title)}</h4>
       </div>
     </div>
-  `).join('');
+  `;
+  }).join('');
 
   const showAllTile = hiddenCount > 0 ? `
     <div class="cert-showall-card" id="showAllCertsCard">
@@ -3950,7 +4222,7 @@ function openCertModal(cert) {
       <img src="${cert.file}" alt="${escapeHtml(cert.title)}">
     </div>
     <h3 class="cert-modal-title">${escapeHtml(cert.title)}</h3>
-    <p class="cert-modal-meta mono">${escapeHtml(cert.issuer)} · ${escapeHtml(cert.date)}</p>
+    <p class="cert-modal-meta mono">${escapeHtml(cert.issuer)} · ${escapeHtml(formatCertDate(cert.on))}</p>
     <div class="cert-modal-actions">
       <button type="button" class="btn btn-primary magnetic" id="certModalViewBtn"><span>Open Full View</span></button>
       <button type="button" class="btn btn-ghost magnetic" id="certModalDownloadBtn"><span>Download</span></button>
@@ -4076,7 +4348,9 @@ function initContactForm() {
       btnText.textContent = 'Message Sent ✓';
       note.textContent = "Sent! It'll land in the inbox shortly.";
       note.classList.add('submit-success');
+      const sender = (form.name.value || '').trim().split(/\s+/)[0];
       form.reset();
+      showSentOverlay(sender);
     } catch (err) {
       console.error(err);
       btnText.textContent = 'Send Failed';
@@ -4092,6 +4366,74 @@ function initContactForm() {
     }, 2600);
   });
 }
+
+/* ---------------- MESSAGE SENT OVERLAY ---------------- */
+const SENT_SPARK_COLORS = ['#4fd8ff', '#8b7cf6', '#f5a623', '#34d399', '#fb7185'];
+let __sentOpen = false;
+
+function showSentOverlay(firstName) {
+  const overlay = document.getElementById('sentOverlay');
+  const sparks = document.getElementById('sentSparks');
+  const sub = document.getElementById('sentSub');
+  if (!overlay) return;
+
+  sub.textContent = firstName
+    ? `Thanks, ${firstName} — it's landed in my inbox. I'll get back to you shortly.`
+    : "Thanks — it's landed in my inbox. I'll get back to you shortly.";
+
+  // Rebuild the burst each time so the animation restarts cleanly.
+  sparks.innerHTML = '';
+  const COUNT = 18;
+  for (let i = 0; i < COUNT; i++) {
+    const s = document.createElement('span');
+    s.className = 'sent-spark';
+    // fan out over a full circle, with a bit of jitter so it doesn't look mechanical
+    const angle = (i / COUNT) * Math.PI * 2 + (Math.random() - 0.5) * 0.35;
+    const dist = 90 + Math.random() * 70;
+    s.style.setProperty('--dx', `${Math.cos(angle) * dist}px`);
+    s.style.setProperty('--dy', `${Math.sin(angle) * dist}px`);
+    s.style.setProperty('--rot', `${(Math.random() - 0.5) * 540}deg`);
+    s.style.background = SENT_SPARK_COLORS[i % SENT_SPARK_COLORS.length];
+    s.style.animationDelay = `${0.42 + Math.random() * 0.12}s`;
+    if (i % 3 === 0) s.style.borderRadius = '50%';
+    sparks.appendChild(s);
+  }
+
+  overlay.setAttribute('aria-hidden', 'false');
+  // Open state is tracked on a flag rather than read back off the class list.
+  // Tying it to the class meant that if the class never landed the hide path
+  // bailed out early and the body scroll lock was never released, leaving the
+  // page frozen — far worse than a missed animation.
+  if (!__sentOpen) {
+    __sentOpen = true;
+    lockBodyScroll();
+  }
+  // Added synchronously: the element is already in the document with its base
+  // styles resolved, so the transition still runs, and this cannot be starved
+  // the way a requestAnimationFrame callback can be in a background tab.
+  overlay.classList.add('open');
+
+  clearTimeout(showSentOverlay._t);
+  showSentOverlay._t = setTimeout(hideSentOverlay, 5200);
+}
+
+function hideSentOverlay() {
+  const overlay = document.getElementById('sentOverlay');
+  if (!overlay) return;
+  clearTimeout(showSentOverlay._t);
+  overlay.classList.remove('open');
+  overlay.setAttribute('aria-hidden', 'true');
+  if (__sentOpen) {
+    __sentOpen = false;
+    unlockBodyScroll();
+  }
+}
+
+document.getElementById('sentClose').addEventListener('click', hideSentOverlay);
+document.getElementById('sentOverlay').addEventListener('click', (e) => {
+  if (e.target.id === 'sentOverlay') hideSentOverlay();
+});
+document.addEventListener('keydown', (e) => { if (e.key === 'Escape') hideSentOverlay(); });
 
 /* ---------------- BACK TO TOP ---------------- */
 function initBackToTop() {


### PR DESCRIPTION
Click ripple left a circle on the page
  A `.loader.done ~ *{ animation:none }` rule I added in the previous change
  (inside the reduced-motion block) matched every top-level element in the
  body. The ripple is appended to <body>, so it is a sibling of the loader:
  its animation was cancelled, `animationend` never fired, the cleanup never
  ran, and a circle was left behind at every click. Removed the rule, and
  backed the cleanup with a timer so an orphaned ripple is impossible
  regardless of CSS. Also positioned the ripple with left/top instead of a
  transform — the keyframes animate `transform` and beat an inline style, so
  every ripple was actually playing from the top-left corner.

Images now load up front
  Certificates load eagerly, and a background prefetch warms the remaining
  certificate and project images once the page is interactive, so nothing
  pops in when a modal is opened. Drip-fed four at a time after an idle
  callback so it never competes with the hero image or the GitHub request.

Light mode contrast
  61 elements were below the WCAG AA threshold; now zero.
  - .orbit-icon and .blueprint-tag kept a hardcoded near-black background, so in light mode the hero's orbiting labels (CAD, Python, ...) were dark text on a dark pill at 1.03:1 — effectively invisible. This was the main complaint.
  - --text-faint (3.48:1) and --cyan (3.68:1) darkened to clear 4.5:1.
  - Timeline, stat and fact accent colours are tuned for a black canvas and came in at 1.8-2.2:1 on white; re-pointed to darker variants.
  - Repo category badges take their colour from an inline style written by JS, so they are darkened with a filter instead of by name. Dark theme tokens are untouched.

Message sent animation
  Submitting the contact form now opens a confirmation overlay: expanding
  rings, a check that draws itself, and an 18-piece confetti burst, with the
  sender's first name in the copy. Dismisses on click, Escape, or after 5s,
  and has a reduced-motion path. The open state is tracked on a flag rather
  than read back off the class list — tying it to the class meant a missed
  class left the body scroll lock permanently engaged.

Certificates
  - Ranked by metal: gold for research and internships, silver for month-long courses, bronze for masterclasses and short sessions. The metal is drawn as a masked gradient ring so it reads as a real edge, with a matching corner badge.
  - Sorted by tier, then newest first inside each tier, so the research internship always leads.
  - Captions are a single line, clipped with an ellipsis; the issuer/date line was dropped from the card and now only appears in the modal.
  - Added the AIMS research internship and the DataCrumbs masterclass entries. Their scans are not in the repo yet, so those two cards show a labelled placeholder and pick up the real image as soon as the files are added.