### PR TITLE
Point the two new certificates at their uploaded files

### DIFF
--- a/index.html
+++ b/index.html
@@ -4084,33 +4084,52 @@ const CERT_TIERS = {
   session:    { rank: 3, metal: 'bronze', label: 'Masterclass' }
 };
 
-const CERTIFICATES = [
-  { file: 'assets/certs/aims-research-internship.jpg', tier: 'research', on: '2026-08-04',
+/* Two of the scans are named with a space ("Certificate 0.jpg"). The space is
+   percent-encoded here so the value is a valid URL everywhere it is used —
+   an <img src>, the fetch() behind Full View, and the download link. */
+const CERTIFICATES = sortCertificates([
+  { file: 'assets/certs/Certificate%200.jpg', tier: 'research', on: '2026-08-04',
     title: 'Research Internship — AIMS Lab, NUST', issuer: 'SMME / SINES, NUST' },
 
   { file: 'assets/certs/certificate-1.jpg', tier: 'course', on: '2026-01-01',
     title: 'AI Revolution — 1 Month AI Practical Course', issuer: 'Study & Jobs Zone' },
 
-  { file: 'assets/certs/datacrumbs-professional-presence.jpg', tier: 'session', on: '2026-08-06',
-    title: 'Build Your Professional Presence', issuer: 'DataCrumbs' },
   { file: 'assets/certs/certificate-2.jpg', tier: 'session', on: '2026-01-06',
     title: 'Agentic AI: From Idea to Deployment', issuer: 'Peer Bridge, NUST Student Community' },
   { file: 'assets/certs/certificate-3.jpg', tier: 'session', on: '2026-01-05',
     title: 'Seizing the Full Potential of AI', issuer: 'ADB Institute' },
   { file: 'assets/certs/certificate-4.jpg', tier: 'session', on: '2026-01-04',
     title: 'Building Digital Clones with AI', issuer: 'DataCrumbs' },
+  // Kept beside the other DataCrumbs certificate rather than sorted by date.
+  { file: 'assets/certs/Certificate%208.jpg', tier: 'session', on: '2026-08-06',
+    title: 'Build Your Professional Presence', issuer: 'DataCrumbs',
+    after: 'Building Digital Clones with AI' },
   { file: 'assets/certs/certificate-5.jpg', tier: 'session', on: '2026-01-03',
     title: 'Cybersecurity', issuer: 'ADB Institute' },
   { file: 'assets/certs/certificate-6.jpg', tier: 'session', on: '2026-01-02',
     title: 'Digital Technology for Energy Efficiency', issuer: 'ADB Institute' },
   { file: 'assets/certs/certificate-7.jpg', tier: 'session', on: '2026-01-01',
     title: 'Accelerating Private Sector Action to Respond to Climate Change', issuer: 'ADB Institute' }
-]
+]);
+
+function sortCertificates(list) {
   // Gold first, then silver, then bronze; newest first inside each tier.
-  .sort((a, b) => {
+  const sorted = list.slice().sort((a, b) => {
     const ra = CERT_TIERS[a.tier].rank, rb = CERT_TIERS[b.tier].rank;
     return ra !== rb ? ra - rb : (b.on || '').localeCompare(a.on || '');
   });
+
+  // `after` then lifts a certificate out of that order and drops it directly
+  // behind a named one, so related certificates can sit together without
+  // having to misstate their date to force the position.
+  for (const cert of sorted.filter(c => c.after)) {
+    const from = sorted.indexOf(cert);
+    sorted.splice(from, 1);
+    const anchor = sorted.findIndex(c => c.title === cert.after);
+    sorted.splice(anchor === -1 ? from : anchor + 1, 0, cert);
+  }
+  return sorted;
+}
 const CERT_PAGE_SIZE = 3;
 let showAllCerts = false;
 


### PR DESCRIPTION
## Why

The two new certificate cards were showing the `scan not uploaded yet` placeholder. The scans were uploaded through the GitHub web UI as **`Certificate 0.jpg`** (AIMS research internship) and **`Certificate 8.jpg`** (DataCrumbs masterclass), but the code still pointed at `aims-research-internship.jpg` and `datacrumbs-professional-presence.jpg` — names that were uploaded and then deleted again in `fd42942` / `6252073`. Nothing was wrong with the rendering; the filenames just never matched.

## Changes

- Reference the real filenames. The space is **percent-encoded** (`Certificate%200.jpg`) so the value is a valid URL in all three places it gets used: the `<img src>`, the `fetch()` behind Full View, and the download link. Verified all three resolve 200.
- Added an optional `after` field that lifts a certificate out of the tier/date order and drops it directly behind a named one. Used to keep the two DataCrumbs certificates adjacent, which the date sort would otherwise split (one is August, the other January). This avoids misstating a date purely to force a position — the modal still shows the real date.
- Moved the sort into `sortCertificates()` now that it runs two passes.

## Resulting order

| # | Certificate | Tier |
|---|---|---|
| 1 | Research Internship — AIMS Lab, NUST | 🥇 gold |
| 2 | AI Revolution — 1 Month AI Practical Course | 🥈 silver |
| 3 | Agentic AI: From Idea to Deployment | 🥉 bronze |
| 4 | Seizing the Full Potential of AI | 🥉 bronze |
| 5 | **Building Digital Clones with AI** | 🥉 bronze |
| 6 | **Build Your Professional Presence** | 🥉 bronze |
| 7 | Cybersecurity | 🥉 bronze |
| 8 | Digital Technology for Energy Efficiency | 🥉 bronze |
| 9 | Accelerating Private Sector Action… | 🥉 bronze |

All 9 images verified loading; no card falls back to the placeholder.

## Reviewer notes

⚠️ **Both new scans have `I am Sorry !!!!!` written in the bottom-left corner of the image itself.** It is mostly cropped out of the card thumbnail but fully visible in Full View and in the downloaded file. Worth re-exporting both without it — no code change needed, just replace the two files under the same names.

⚠️ **The untracked `.gitattributes` remains a live hazard.** It is a Unity template that routes `*.jpg` through Git LFS. With it in place, `git diff` reports `Certificate 0.jpg` as `Bin 1013434 -> 132 bytes` — git wants to replace the 1 MB JPEG with an LFS pointer, and Vercel does not resolve pointers on a default build, so committing it would break both images on the live site. The web-UI uploads escaped this because GitHub stored them as plain blobs. I moved the file aside while committing and restored it untouched; verified the committed blob is still the full 1,013,434 bytes. **Recommend deleting it** — nothing in this repo is a Unity project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)